### PR TITLE
Sde 28 aws elasticsearch

### DIFF
--- a/aws-infrastructure/aws-infrastructure.tf
+++ b/aws-infrastructure/aws-infrastructure.tf
@@ -7,6 +7,7 @@ module "lambda" {
   project                   = var.project
   environment               = var.environment
   api_gateway_execution_arn = module.api-gateway.api_gateway_execution_arn
+  elasticsearch_arn         = module.elasticsearch.elasticsearch_arn
 }
 
 module "api-gateway" {
@@ -17,7 +18,7 @@ module "api-gateway" {
   search_lambda_invoke_arn  = module.lambda.search_lambda_invoke_arn
 }
 
-module "elasticserch" {
+module "elasticsearch" {
   source                    = "./modules/elasticsearch"
   project                   = var.project
   environment               = var.environment

--- a/aws-infrastructure/aws-infrastructure.tf
+++ b/aws-infrastructure/aws-infrastructure.tf
@@ -16,3 +16,10 @@ module "api-gateway" {
   environment               = var.environment
   search_lambda_invoke_arn  = module.lambda.search_lambda_invoke_arn
 }
+
+module "elasticserch" {
+  source                    = "./modules/elasticsearch"
+  project                   = var.project
+  environment               = var.environment
+  allowed_public_ip         = var.allowed_public_ip
+}

--- a/aws-infrastructure/modules/elasticsearch/main.tf
+++ b/aws-infrastructure/modules/elasticsearch/main.tf
@@ -15,7 +15,7 @@ resource "aws_elasticsearch_domain" "test-domain" {
     volume_size = 10
   }
 
-  //access_policies = data.template_file.access_policy.rendered
+  access_policies = data.template_file.access_policy.rendered
 
   tags = {
     Name        = "${var.project}-${var.environment}-es-test-domain"

--- a/aws-infrastructure/modules/elasticsearch/main.tf
+++ b/aws-infrastructure/modules/elasticsearch/main.tf
@@ -1,0 +1,40 @@
+resource "aws_elasticsearch_domain" "test-domain" {
+  domain_name = "${var.project}-${var.environment}-es-test-domain"
+
+  cluster_config {
+    instance_type = "t2.micro.elasticsearch"
+    instance_count = 1
+  }
+
+  snapshot_options {
+    automated_snapshot_start_hour = 23
+  }
+
+  ebs_options {
+    ebs_enabled = true
+    volume_size = 10
+  }
+
+  //access_policies = data.template_file.access_policy.rendered
+
+  tags = {
+    Name        = "${var.project}-${var.environment}-es-test-domain"
+    Environment = var.environment
+    Project     = var.project
+  }
+}
+
+data "aws_region" "current" {}
+
+data "aws_caller_identity" "current" {}
+
+data "template_file" "access_policy" {
+  template = file("${path.module}/policies/elasticsearch_access_policy.json")
+
+  vars = {
+    elastic_search_arn  = "arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.project}-${var.environment}-es-test-domain"
+    account_id          = data.aws_caller_identity.current.account_id
+    allowed_public_ip   = var.allowed_public_ip
+  }
+}
+

--- a/aws-infrastructure/modules/elasticsearch/output.tf
+++ b/aws-infrastructure/modules/elasticsearch/output.tf
@@ -1,0 +1,7 @@
+output "endpoint" {
+  value = "https://${aws_elasticsearch_domain.test-domain.endpoint}"
+}
+
+output "kibana_endpoint" {
+  value = "https://${aws_elasticsearch_domain.test-domain.kibana_endpoint}"
+}

--- a/aws-infrastructure/modules/elasticsearch/output.tf
+++ b/aws-infrastructure/modules/elasticsearch/output.tf
@@ -5,3 +5,7 @@ output "endpoint" {
 output "kibana_endpoint" {
   value = "https://${aws_elasticsearch_domain.test-domain.kibana_endpoint}"
 }
+
+output "elasticsearch_arn" {
+  value = aws_elasticsearch_domain.test-domain.arn
+}

--- a/aws-infrastructure/modules/elasticsearch/policies/elasticsearch_access_policy.json
+++ b/aws-infrastructure/modules/elasticsearch/policies/elasticsearch_access_policy.json
@@ -1,0 +1,34 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "${account_id}"
+        ]
+      },
+      "Action": [
+        "es:*"
+      ],
+      "Resource": "${elastic_search_arn}/*"
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "*"
+      },
+      "Action": [
+        "es:*"
+      ],
+      "Condition": {
+        "IpAddress": {
+          "aws:SourceIp": [
+            "${allowed_public_ip}"
+          ]
+        }
+      },
+      "Resource": "${elastic_search_arn}/*"
+    }
+  ]
+}

--- a/aws-infrastructure/modules/elasticsearch/policies/elasticsearch_access_policy.json
+++ b/aws-infrastructure/modules/elasticsearch/policies/elasticsearch_access_policy.json
@@ -4,18 +4,6 @@
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": [
-          "${account_id}"
-        ]
-      },
-      "Action": [
-        "es:*"
-      ],
-      "Resource": "${elastic_search_arn}/*"
-    },
-    {
-      "Effect": "Allow",
-      "Principal": {
         "AWS": "*"
       },
       "Action": [

--- a/aws-infrastructure/modules/elasticsearch/variables.tf
+++ b/aws-infrastructure/modules/elasticsearch/variables.tf
@@ -1,7 +1,3 @@
-variable "region" {
-  description = "The AWS region name"
-}
-
 variable "project" {
   description = "The name of the project"
 }
@@ -11,6 +7,7 @@ variable "environment" {
 }
 
 variable "allowed_public_ip" {
-  description = "A public IP which is allowed access to the elasticsearch cluster for maintenance purposes"
+  description = "A public IP which is allowed access to the cluster for maintenance purposes"
 }
+
 

--- a/aws-infrastructure/modules/lambda/main.tf
+++ b/aws-infrastructure/modules/lambda/main.tf
@@ -5,21 +5,29 @@ data "archive_file" "search" {
   output_path = "${path.module}/search_lambda_function_payload.zip"
 }
 
+data "template_file" "lambda_exec_policy" {
+  template = file("${path.module}/policies/lambda_exec_policy.json")
+
+  vars = {
+    elasticsearch_arn = var.elasticsearch_arn
+  }
+}
+
 resource "aws_iam_role" "lambda_exec_role" {
   name = "${var.project}-${var.environment}-lambda-exec-role"
 
   assume_role_policy = file("${path.module}/policies/lambda_exec_role.json")
 }
 
-resource "aws_iam_policy" "lambda_logging" {
+resource "aws_iam_policy" "lambda_policy" {
   name = "${var.project}-${var.environment}-lambda-exec-policy"
 
-  policy = file("${path.module}/policies/lambda_exec_policy.json")
+  policy = data.template_file.lambda_exec_policy.rendered
 }
 
-resource "aws_iam_role_policy_attachment" "lambda_logs" {
+resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
   role        = aws_iam_role.lambda_exec_role.name
-  policy_arn  = aws_iam_policy.lambda_logging.arn
+  policy_arn  = aws_iam_policy.lambda_policy.arn
 }
 
 resource "aws_lambda_function" "search_lambda" {

--- a/aws-infrastructure/modules/lambda/output.tf
+++ b/aws-infrastructure/modules/lambda/output.tf
@@ -1,3 +1,4 @@
 output "search_lambda_invoke_arn" {
   value = aws_lambda_function.search_lambda.invoke_arn
 }
+

--- a/aws-infrastructure/modules/lambda/policies/lambda_exec_policy.json
+++ b/aws-infrastructure/modules/lambda/policies/lambda_exec_policy.json
@@ -9,6 +9,14 @@
       ],
       "Resource": "arn:aws:logs:*:*:*",
       "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "es:ESHttp*"
+      ],
+      "Resource": "${elasticsearch_arn}/*",
+      "Effect": "Allow"
     }
+
   ]
 }

--- a/aws-infrastructure/modules/lambda/variables.tf
+++ b/aws-infrastructure/modules/lambda/variables.tf
@@ -9,3 +9,7 @@ variable "environment" {
 variable "api_gateway_execution_arn" {
   description = "The API Gateway execution ARN, needed to we can grant permission to allow API gateway to run our lambdas"
 }
+
+variable "elasticsearch_arn" {
+  description = "The Elasticsearch arn we need to grant our lambda permission to access"
+}

--- a/aws-infrastructure/output.tf
+++ b/aws-infrastructure/output.tf
@@ -3,9 +3,9 @@ output "api_gateway_invoke_url" {
 }
 
 output "elasticsearch_endpoint" {
-  value = module.elasticserch.endpoint
+  value = module.elasticsearch.endpoint
 }
 
 output "elasticsearch_kibana_endpoint" {
-  value = module.elasticserch.kibana_endpoint
+  value = module.elasticsearch.kibana_endpoint
 }

--- a/aws-infrastructure/output.tf
+++ b/aws-infrastructure/output.tf
@@ -1,3 +1,11 @@
 output "api_gateway_invoke_url" {
   value = module.api-gateway.invoke_url
 }
+
+output "elasticsearch_endpoint" {
+  value = module.elasticserch.endpoint
+}
+
+output "elasticsearch_kibana_endpoint" {
+  value = module.elasticserch.kibana_endpoint
+}

--- a/aws-infrastructure/terraform.tfvars
+++ b/aws-infrastructure/terraform.tfvars
@@ -1,3 +1,4 @@
 project                = "sde"
 environment            = "dev"
 region                 = "eu-west-1"
+allowed_public_ip      = "213.86.214.142"


### PR DESCRIPTION
Creates a 1.5 version of Elasticsearch with a t2.micro.elasticsearch as it's the cheapest. We can change to latest version 6.7 if required, but will require a t2.small.elasticsearch which costs a little bit more - no big deal to change if required.

I've added permissions to the Elasticsearch cluster to allow admin access to it from:
- our SL IP address (213.86.214.142)
- added allow access to the lambda to be able to access the Elasticsearch cluster

Script outputs the following:
```
Apply complete! Resources: 11 added, 0 changed, 0 destroyed.

Outputs:

api_gateway_invoke_url = https://yx5mg61kkf.execute-api.eu-west-1.amazonaws.com/dev
elasticsearch_endpoint = https://search-sde-dev-es-test-domain-hplsrf7hatpadkuvakzrf3j7wq.eu-west-1.es.amazonaws.com
elasticsearch_kibana_endpoint = https://search-sde-dev-es-test-domain-hplsrf7hatpadkuvakzrf3j7wq.eu-west-1.es.amazonaws.com/_plugin/kibana/
```