### PR TITLE
Sde 33 add env var for elasticsearch endpoint to lambda

### DIFF
--- a/aws-infrastructure/aws-infrastructure.tf
+++ b/aws-infrastructure/aws-infrastructure.tf
@@ -13,6 +13,7 @@ module "lambda" {
   environment               = var.environment
   api_gateway_execution_arn = module.api-gateway.api_gateway_execution_arn
   elasticsearch_arn         = module.elasticsearch.elasticsearch_arn
+  elasticsearch_endpoint    = module.elasticsearch.endpoint
 }
 
 module "api-gateway" {

--- a/aws-infrastructure/aws-infrastructure.tf
+++ b/aws-infrastructure/aws-infrastructure.tf
@@ -1,9 +1,14 @@
+locals {
+  name_prefix =  "${var.project}-${var.environment}"
+}
+
 provider "aws" {
   region  = var.region
 }
 
 module "lambda" {
   source                    = "./modules/lambda"
+  name_prefix               = local.name_prefix
   project                   = var.project
   environment               = var.environment
   api_gateway_execution_arn = module.api-gateway.api_gateway_execution_arn
@@ -12,7 +17,7 @@ module "lambda" {
 
 module "api-gateway" {
   source                    = "./modules/api_gateway"
-  region                    = var.region
+  name_prefix               = local.name_prefix
   project                   = var.project
   environment               = var.environment
   search_lambda_invoke_arn  = module.lambda.search_lambda_invoke_arn
@@ -20,6 +25,7 @@ module "api-gateway" {
 
 module "elasticsearch" {
   source                    = "./modules/elasticsearch"
+  name_prefix               = local.name_prefix
   project                   = var.project
   environment               = var.environment
   allowed_public_ip         = var.allowed_public_ip

--- a/aws-infrastructure/modules/api_gateway/main.tf
+++ b/aws-infrastructure/modules/api_gateway/main.tf
@@ -2,7 +2,7 @@
 The API Gateway
 ======*/
 resource "aws_api_gateway_rest_api" "api_gateway" {
-  name        = "${var.project}-${var.environment}-api-gateway"
+  name        = "${var.name_prefix}-api-gateway"
   description = "${var.project} API Gateway"
 
   endpoint_configuration {

--- a/aws-infrastructure/modules/api_gateway/variables.tf
+++ b/aws-infrastructure/modules/api_gateway/variables.tf
@@ -1,5 +1,5 @@
-variable "region" {
-  description = "The AWS region name"
+variable "name_prefix" {
+  description = "Prefix to use when naming resources"
 }
 
 variable "project" {

--- a/aws-infrastructure/modules/elasticsearch/main.tf
+++ b/aws-infrastructure/modules/elasticsearch/main.tf
@@ -1,5 +1,5 @@
 resource "aws_elasticsearch_domain" "test-domain" {
-  domain_name = "${var.project}-${var.environment}-es-test-domain"
+  domain_name = "${var.name_prefix}-es-test-domain"
 
   cluster_config {
     instance_type = "t2.micro.elasticsearch"
@@ -18,7 +18,7 @@ resource "aws_elasticsearch_domain" "test-domain" {
   access_policies = data.template_file.access_policy.rendered
 
   tags = {
-    Name        = "${var.project}-${var.environment}-es-test-domain"
+    Name        = "${var.name_prefix}-es-test-domain"
     Environment = var.environment
     Project     = var.project
   }

--- a/aws-infrastructure/modules/elasticsearch/variables.tf
+++ b/aws-infrastructure/modules/elasticsearch/variables.tf
@@ -1,3 +1,7 @@
+variable "name_prefix" {
+  description = "Prefix to use when naming resources"
+}
+
 variable "project" {
   description = "The name of the project"
 }

--- a/aws-infrastructure/modules/lambda/main.tf
+++ b/aws-infrastructure/modules/lambda/main.tf
@@ -14,13 +14,19 @@ data "template_file" "lambda_exec_policy" {
 }
 
 resource "aws_iam_role" "lambda_exec_role" {
-  name = "${var.project}-${var.environment}-lambda-exec-role"
+  name = "${var.name_prefix}-lambda-exec-role"
 
   assume_role_policy = file("${path.module}/policies/lambda_exec_role.json")
+
+  tags = {
+    Name        = "${var.name_prefix}-lambda-exec-role"
+    Environment = var.environment
+    Project     = var.project
+  }
 }
 
 resource "aws_iam_policy" "lambda_policy" {
-  name = "${var.project}-${var.environment}-lambda-exec-policy"
+  name = "${var.name_prefix}-lambda-exec-policy"
 
   policy = data.template_file.lambda_exec_policy.rendered
 }
@@ -33,14 +39,14 @@ resource "aws_iam_role_policy_attachment" "lambda_policy_attachment" {
 resource "aws_lambda_function" "search_lambda" {
   filename          = data.archive_file.search.output_path
   source_code_hash  = data.archive_file.search.output_base64sha256
-  function_name     = "${var.project}-${var.environment}-search"
+  function_name     = "${var.name_prefix}-search"
   role              = aws_iam_role.lambda_exec_role.arn
   handler           = "index.handler"
   runtime           = "nodejs8.10"
   description       = "SDE search lambda"
 
   tags = {
-    Name        = "${var.project}-${var.environment}-search"
+    Name        = "${var.name_prefix}-search"
     Environment = var.environment
     Project     = var.project
   }

--- a/aws-infrastructure/modules/lambda/main.tf
+++ b/aws-infrastructure/modules/lambda/main.tf
@@ -45,6 +45,12 @@ resource "aws_lambda_function" "search_lambda" {
   runtime           = "nodejs8.10"
   description       = "SDE search lambda"
 
+  environment {
+    variables = {
+      ES_SEARCH_API = var.elasticsearch_endpoint
+    }
+  }
+
   tags = {
     Name        = "${var.name_prefix}-search"
     Environment = var.environment

--- a/aws-infrastructure/modules/lambda/variables.tf
+++ b/aws-infrastructure/modules/lambda/variables.tf
@@ -1,3 +1,7 @@
+variable "name_prefix" {
+  description = "Prefix to use when naming resources"
+}
+
 variable "project" {
   description = "The name of the project"
 }

--- a/aws-infrastructure/modules/lambda/variables.tf
+++ b/aws-infrastructure/modules/lambda/variables.tf
@@ -17,3 +17,7 @@ variable "api_gateway_execution_arn" {
 variable "elasticsearch_arn" {
   description = "The Elasticsearch arn we need to grant our lambda permission to access"
 }
+
+variable "elasticsearch_endpoint" {
+  description = "The Elasticsearch endpoint, that's set as an environment variable for the lambdas"
+}


### PR DESCRIPTION
Added environment variable ES_SEARCH_API to lambda, which points to the elasticsearch endpoint.

Did some small bits of refactoring, by passing in the AWS naming prefix to each module, rather than each module replicating the same code.

Added missing tags to lambda_exec_role