### PR TITLE
SDE-36: Fixed alias permission causing unnecessary delta changes where none were required

### DIFF
--- a/aws-infrastructure/modules/lambda/main.tf
+++ b/aws-infrastructure/modules/lambda/main.tf
@@ -61,7 +61,9 @@ resource "aws_lambda_function" "search_lambda" {
 resource "aws_lambda_permission" "lambda_alias_permission" {
   statement_id  = "AllowAPIGatewayInvoke"
   action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_alias.search_lambda_alias.arn
+  function_name = aws_lambda_function.search_lambda.arn
+  qualifier = aws_lambda_alias.search_lambda_alias.name
+
   principal     = "apigateway.amazonaws.com"
 
   # The /*/*/* part allows invocation from any stage, method and resource path
@@ -72,6 +74,6 @@ resource "aws_lambda_permission" "lambda_alias_permission" {
 resource "aws_lambda_alias" "search_lambda_alias" {
   name = "DEV"
   description = "Alias to the ${aws_lambda_function.search_lambda.function_name}"
-  function_name = "${aws_lambda_function.search_lambda.function_name}"
+  function_name = aws_lambda_function.search_lambda.function_name
   function_version = "$LATEST"
 }


### PR DESCRIPTION
Fixed aws_lambda_permission.lambda_alias_permission which incorrectly used the lambda alias ARN, rather than the lambda ARN + qualifier.