### PR TITLE
SDE-39: Upgraded Elasticsearch to version 6.7 from 1.5

### DIFF
--- a/aws-infrastructure/modules/elasticsearch/main.tf
+++ b/aws-infrastructure/modules/elasticsearch/main.tf
@@ -1,8 +1,9 @@
 resource "aws_elasticsearch_domain" "test-domain" {
   domain_name = "${var.name_prefix}-es-test-domain"
+  elasticsearch_version = "6.7"
 
   cluster_config {
-    instance_type = "t2.micro.elasticsearch"
+    instance_type = "t2.small.elasticsearch"
     instance_count = 1
   }
 


### PR DESCRIPTION
The client being used required a later version to work correctly. This means we have to use a t2.small rather than a t2.micro