### PR TITLE
SDE-32: Enable CORS for search API Gateway endpoint

### DIFF
--- a/aws-infrastructure/modules/api_gateway/cors/headers.tf
+++ b/aws-infrastructure/modules/api_gateway/cors/headers.tf
@@ -1,0 +1,68 @@
+# Copyright (c) 2018-2019 Martin Donath <martin.donath@squidfunk.com>
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+# -----------------------------------------------------------------------------
+# Locals
+# -----------------------------------------------------------------------------
+
+# local.*
+locals {
+  headers = "${
+    map(
+      "Access-Control-Allow-Headers"    , "'${join(",", var.allow_headers)}'",
+      "Access-Control-Allow-Methods"    , "'${join(",", var.allow_methods)}'",
+      "Access-Control-Allow-Origin"     , "'${var.allow_origin}'",
+      "Access-Control-Max-Age"          , "'${var.allow_max_age}'",
+      "Access-Control-Allow-Credentials", "${var.allow_credentials ? "'true'" : ""}"
+    )
+  }"
+
+  # Pick non-empty header values
+  header_values = "${compact(values(local.headers))}"
+
+  # Pick names that from non-empty header values
+  header_names = "${matchkeys(
+    keys(local.headers),
+    values(local.headers),
+    local.header_values
+  )}"
+
+  # Parameter names for method and integration responses
+  parameter_names = "${
+    formatlist("method.response.header.%s", local.header_names)
+  }"
+
+  # Map parameter list to "true" values
+  true_list = "${
+    split("|", replace(join("|", local.parameter_names), "/[^|]+/", "true"))
+  }"
+
+  # Integration response parameters
+  integration_response_parameters = "${zipmap(
+    local.parameter_names,
+    local.header_values
+  )}"
+
+  # Method response parameters
+  method_response_parameters = "${zipmap(
+    local.parameter_names,
+    local.true_list
+  )}"
+}

--- a/aws-infrastructure/modules/api_gateway/cors/main.tf
+++ b/aws-infrastructure/modules/api_gateway/cors/main.tf
@@ -1,0 +1,77 @@
+# Copyright (c) 2018-2019 Martin Donath <martin.donath@squidfunk.com>
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+# -----------------------------------------------------------------------------
+# Resources: API Gateway
+# -----------------------------------------------------------------------------
+
+# aws_api_gateway_method._
+resource "aws_api_gateway_method" "_" {
+  rest_api_id   = "${var.api_id}"
+  resource_id   = "${var.api_resource_id}"
+  http_method   = "OPTIONS"
+  authorization = "NONE"
+}
+
+# aws_api_gateway_integration._
+resource "aws_api_gateway_integration" "_" {
+  rest_api_id = "${var.api_id}"
+  resource_id = "${var.api_resource_id}"
+  http_method = "${aws_api_gateway_method._.http_method}"
+
+  type = "MOCK"
+
+  request_templates = {
+    "application/json" = "{ \"statusCode\": 200 }"
+  }
+}
+
+# aws_api_gateway_integration_response._
+resource "aws_api_gateway_integration_response" "_" {
+  rest_api_id = "${var.api_id}"
+  resource_id = "${var.api_resource_id}"
+  http_method = "${aws_api_gateway_method._.http_method}"
+  status_code = 200
+
+  response_parameters = "${local.integration_response_parameters}"
+
+  depends_on = [
+    "aws_api_gateway_integration._",
+    "aws_api_gateway_method_response._",
+  ]
+}
+
+# aws_api_gateway_method_response._
+resource "aws_api_gateway_method_response" "_" {
+  rest_api_id = "${var.api_id}"
+  resource_id = "${var.api_resource_id}"
+  http_method = "${aws_api_gateway_method._.http_method}"
+  status_code = 200
+
+  response_parameters = "${local.method_response_parameters}"
+
+  response_models = {
+    "application/json" = "Empty"
+  }
+
+  depends_on = [
+    "aws_api_gateway_method._",
+  ]
+}

--- a/aws-infrastructure/modules/api_gateway/cors/variables.tf
+++ b/aws-infrastructure/modules/api_gateway/cors/variables.tf
@@ -1,0 +1,87 @@
+# Copyright (c) 2018-2019 Martin Donath <martin.donath@squidfunk.com>
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to
+# deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+# sell copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+# IN THE SOFTWARE.
+
+# -----------------------------------------------------------------------------
+# Variables: API Gateway
+# -----------------------------------------------------------------------------
+
+# var.api_id
+variable "api_id" {
+  description = "API identifier"
+}
+
+# var.api_resource_id
+variable "api_resource_id" {
+  description = "API resource identifier"
+}
+
+# -----------------------------------------------------------------------------
+# Variables: CORS-related
+# -----------------------------------------------------------------------------
+
+# var.allow_headers
+variable "allow_headers" {
+  description = "Allow headers"
+  type        = "list"
+
+  default = [
+    "Authorization",
+    "Content-Type",
+    "X-Amz-Date",
+    "X-Amz-Security-Token",
+    "X-Api-Key",
+  ]
+}
+
+# var.allow_methods
+variable "allow_methods" {
+  description = "Allow methods"
+  type        = "list"
+
+  default = [
+    "OPTIONS",
+    "HEAD",
+    "GET",
+    "POST",
+    "PUT",
+    "PATCH",
+    "DELETE",
+  ]
+}
+
+# var.allow_origin
+variable "allow_origin" {
+  description = "Allow origin"
+  type        = "string"
+  default     = "*"
+}
+
+# var.allow_max_age
+variable "allow_max_age" {
+  description = "Allow response caching time"
+  type        = "string"
+  default     = "7200"
+}
+
+# var.allowed_credentials
+variable "allow_credentials" {
+  description = "Allow credentials"
+  default     = false
+}

--- a/aws-infrastructure/modules/api_gateway/main.tf
+++ b/aws-infrastructure/modules/api_gateway/main.tf
@@ -38,3 +38,10 @@ resource "aws_api_gateway_deployment" "deployment" {
   rest_api_id = aws_api_gateway_rest_api.api_gateway.id
   stage_name  = var.environment
 }
+
+module "cors" {
+  source = "./cors"
+
+  api_id          = aws_api_gateway_rest_api.api_gateway.id
+  api_resource_id = aws_api_gateway_resource.search_api_resource.id
+}


### PR DESCRIPTION
Used existing CORS library from Github as it works fine which is in modules/api-gateway/cors

Driving code is in modules/api-gateway/main.tf and just needs:
- api_gateway **id**
- search resource **id**