### PR TITLE
SDE-53: Terraform S3 bucket for generate report

### DIFF
--- a/aws-infrastructure/aws-infrastructure.tf
+++ b/aws-infrastructure/aws-infrastructure.tf
@@ -19,6 +19,7 @@ module "lambda_shared_policy" {
   project                   = var.project
   environment               = var.environment
   elasticsearch_arn         = module.elasticsearch.elasticsearch_arn
+  s3_arn                    = module.s3-bucket.arn
 }
 
 #
@@ -99,7 +100,10 @@ module "lambda-generate-report" {
 
   source_arn                = local.api_gateway_source_arn
 
-  lambda_env_map            = {ES_SEARCH_API : module.elasticsearch.endpoint}
+  lambda_env_map            = {
+                                ES_SEARCH_API  : module.elasticsearch.endpoint,
+                                S3_BUCKET_NAME : module.s3-bucket.bucket_name
+                              }
 }
 
 #
@@ -134,4 +138,11 @@ module "elasticsearch" {
   project                   = var.project
   environment               = var.environment
   allowed_public_ip         = var.allowed_public_ip
+}
+
+module "s3-bucket" {
+  source                    = "./modules/s3"
+  name_prefix               = local.name_prefix
+  project                   = var.project
+  environment               = var.environment
 }

--- a/aws-infrastructure/modules/lambda/policies/lambda_exec_policy.json
+++ b/aws-infrastructure/modules/lambda/policies/lambda_exec_policy.json
@@ -16,7 +16,14 @@
       ],
       "Resource": "${elasticsearch_arn}/*",
       "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "s3:PutObject",
+        "s3:PutObjectAcl"
+      ],
+      "Resource": "${elasticsearch_arn}/*",
+      "Effect": "Allow"
     }
-
   ]
 }

--- a/aws-infrastructure/modules/lambda/variables.tf
+++ b/aws-infrastructure/modules/lambda/variables.tf
@@ -24,7 +24,7 @@ variable "lambda_env_map" {
 }
 
 variable "source_arn" {
-  description = "The URN of the resource which will invoke this lambda, so appropriate permissions can be set"
+  description = "The ARN of the resource which will invoke this lambda, so appropriate permissions can be set"
 }
 
 variable "lambda_iam_role_arn" {

--- a/aws-infrastructure/modules/lambda_shared_policy/main.tf
+++ b/aws-infrastructure/modules/lambda_shared_policy/main.tf
@@ -3,6 +3,7 @@ data "template_file" "lambda_exec_policy" {
 
   vars = {
     elasticsearch_arn = var.elasticsearch_arn
+    s3_arn            = var.s3_arn
   }
 }
 

--- a/aws-infrastructure/modules/lambda_shared_policy/policies/lambda_exec_policy.json
+++ b/aws-infrastructure/modules/lambda_shared_policy/policies/lambda_exec_policy.json
@@ -16,7 +16,14 @@
       ],
       "Resource": "${elasticsearch_arn}/*",
       "Effect": "Allow"
+    },
+    {
+      "Action": [
+        "s3:PutObject",
+        "s3:PutObjectAcl"
+      ],
+      "Resource": "${s3_arn}/*",
+      "Effect": "Allow"
     }
-
   ]
 }

--- a/aws-infrastructure/modules/s3/main.tf
+++ b/aws-infrastructure/modules/s3/main.tf
@@ -1,0 +1,27 @@
+resource "aws_s3_bucket" "sde-bucket" {
+  bucket = "${var.name_prefix}-scott-logic"
+  acl = "public-read"
+
+  lifecycle_rule {
+    id = "${var.name_prefix}-one-day-life"
+    enabled = true
+
+    expiration {
+      days = "1"
+    }
+
+    tags = {
+      Name = "${var.name_prefix}-one-day-life"
+      Environment = var.environment
+      Project     = var.project
+    }
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-scott-logic"
+    Environment = var.environment
+    Project     = var.project
+  }
+}
+
+

--- a/aws-infrastructure/modules/s3/output.tf
+++ b/aws-infrastructure/modules/s3/output.tf
@@ -1,0 +1,7 @@
+output "arn" {
+  value = aws_s3_bucket.sde-bucket.arn
+}
+
+output "bucket_name" {
+  value = aws_s3_bucket.sde-bucket.bucket
+}

--- a/aws-infrastructure/modules/s3/variables.tf
+++ b/aws-infrastructure/modules/s3/variables.tf
@@ -9,11 +9,3 @@ variable "project" {
 variable "environment" {
   description = "The name of the environment we're creating, i.e prod, uat, dev etc."
 }
-
-variable "elasticsearch_arn" {
-  description = "The Elasticsearch arn we need to grant our lambda permission to access"
-}
-
-variable "s3_arn" {
-  description = "The ARN of the S3 bucket all lambda will have access to"
-}


### PR DESCRIPTION
Changes made:
- New S3 bucket, with 1 day expiry set
- Added Put permissions into lambda exec policy to our bucket
- pass environment variable into generate-report lambda with bucket name
